### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-static-web-apps-green-tree-0dc778e03.yml
+++ b/.github/workflows/azure-static-web-apps-green-tree-0dc778e03.yml
@@ -1,4 +1,7 @@
 name: Azure Static Web Apps CI/CD
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/JeffreyMawuko/Brassland/security/code-scanning/4](https://github.com/JeffreyMawuko/Brassland/security/code-scanning/4)

To fix this issue, we need to add a `permissions` block to the workflow YAML file to explicitly set the permissions available to the GITHUB_TOKEN in all jobs. Since the workflow interacts with pull requests (making comments and closing them) using the `repo_token` and does deployments, the minimal required permissions seem to be `contents: read` and `pull-requests: write`. The best way is to place the `permissions` block at the root level, so it applies to all jobs, unless a job needs special permissions, in which case it can be set per-job. The `permissions` block should be inserted after the `name` field and before the `on:` field for a root-level permissions policy.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
